### PR TITLE
Add underscores to pkgIDs in output

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 			color = "paleturquoise"
 		}
 
-		fmt.Printf("%d [label=\"%s\" style=\"filled\" color=\"%s\"];\n", pkgId, pkgName, color)
+		fmt.Printf("_%d [label=\"%s\" style=\"filled\" color=\"%s\"];\n", pkgId, pkgName, color)
 
 		// Don't render imports from packages in Goroot
 		if pkg.Goroot && !*delveGoroot {
@@ -107,7 +107,7 @@ func main() {
 			}
 
 			impId := getId(imp)
-			fmt.Printf("%d -> %d;\n", pkgId, impId)
+			fmt.Printf("_%d -> _%d;\n", pkgId, impId)
 		}
 	}
 	fmt.Println("}")


### PR DESCRIPTION
http://www.graphviz.org/doc/info/lang.html specifies node ID must not start with a digit.

"dot" doesn't seem to care, other tools to work with GraphVis dot files do.
