### PR TITLE
fix detection of vendored packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func processPackage(root string, pkgName string, level int) error {
 
 	for _, imp := range getImports(pkg) {
 		if _, ok := pkgs[imp]; !ok {
-			if err := processPackage(root, imp, level); err != nil {
+			if err := processPackage(pkg.Dir, imp, level); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
When doing recursive package processing, pass the path to the package
as a root for packages search. This fixes detection of vendored packages
if the vendor directory is somewhere in subdirectory. Before this commit
it finds vendored packages only if they are in "./vendor", where "." is
the current directory of godepgraph process.

Example repo for testing: https://github.com/starius/godepgraph-error