### PR TITLE
Readable DOT node IDs and enhanced error handling

### DIFF
--- a/expected.txt
+++ b/expected.txt
@@ -1,17 +1,17 @@
 digraph godep {
-_0 [label="flag" style="filled" color="palegreen"];
-_1 [label="fmt" style="filled" color="palegreen"];
-_2 [label="github.com/kisielk/godepgraph" style="filled" color="paleturquoise"];
-_2 -> _0;
-_2 -> _1;
-_2 -> _3;
-_2 -> _4;
-_2 -> _5;
-_2 -> _6;
-_2 -> _7;
-_3 [label="go/build" style="filled" color="palegreen"];
-_4 [label="log" style="filled" color="palegreen"];
-_5 [label="os" style="filled" color="palegreen"];
-_6 [label="sort" style="filled" color="palegreen"];
-_7 [label="strings" style="filled" color="palegreen"];
+"flag" [label="flag" style="filled" color="palegreen"];
+"fmt" [label="fmt" style="filled" color="palegreen"];
+"github.com/kisielk/godepgraph" [label="github.com/kisielk/godepgraph" style="filled" color="paleturquoise"];
+"github.com/kisielk/godepgraph" -> "flag";
+"github.com/kisielk/godepgraph" -> "fmt";
+"github.com/kisielk/godepgraph" -> "go/build";
+"github.com/kisielk/godepgraph" -> "log";
+"github.com/kisielk/godepgraph" -> "os";
+"github.com/kisielk/godepgraph" -> "sort";
+"github.com/kisielk/godepgraph" -> "strings";
+"go/build" [label="go/build" style="filled" color="palegreen"];
+"log" [label="log" style="filled" color="palegreen"];
+"os" [label="os" style="filled" color="palegreen"];
+"sort" [label="sort" style="filled" color="palegreen"];
+"strings" [label="strings" style="filled" color="palegreen"];
 }

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 		log.Fatalf("failed to get cwd: %s", err)
 	}
 	for _, a := range args {
-		if err := processPackage(cwd, a, 0); err != nil {
+		if err := processPackage(cwd, a, 0, ""); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -121,7 +121,7 @@ func main() {
 	fmt.Println("}")
 }
 
-func processPackage(root string, pkgName string, level int) error {
+func processPackage(root string, pkgName string, level int, importedBy string) error {
 	if level++; level > *maxLevel {
 		return nil
 	}
@@ -131,7 +131,7 @@ func processPackage(root string, pkgName string, level int) error {
 
 	pkg, err := buildContext.Import(pkgName, root, 0)
 	if err != nil {
-		return fmt.Errorf("failed to import %s: %s", pkgName, err)
+		return fmt.Errorf("failed to import %s (imported at level %d by %s): %s", pkgName, level, importedBy, err)
 	}
 
 	if isIgnored(pkg) {
@@ -147,7 +147,7 @@ func processPackage(root string, pkgName string, level int) error {
 
 	for _, imp := range getImports(pkg) {
 		if _, ok := pkgs[imp]; !ok {
-			if err := processPackage(pkg.Dir, imp, level); err != nil {
+			if err := processPackage(pkg.Dir, imp, level, pkgName); err != nil {
 				return err
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -11,9 +11,8 @@ import (
 )
 
 var (
-	pkgs   map[string]*build.Package
-	ids    map[string]int
-	nextId int
+	pkgs map[string]*build.Package
+	ids  map[string]string
 
 	ignored = map[string]bool{
 		"C": true,
@@ -38,7 +37,7 @@ var (
 
 func main() {
 	pkgs = make(map[string]*build.Package)
-	ids = make(map[string]int)
+	ids = make(map[string]string)
 	flag.Parse()
 
 	args := flag.Args()
@@ -102,7 +101,7 @@ func main() {
 			color = "paleturquoise"
 		}
 
-		fmt.Printf("_%d [label=\"%s\" style=\"filled\" color=\"%s\"];\n", pkgId, pkgName, color)
+		fmt.Printf("%s [label=\"%s\" style=\"filled\" color=\"%s\"];\n", pkgId, pkgName, color)
 
 		// Don't render imports from packages in Goroot
 		if pkg.Goroot && !*delveGoroot {
@@ -116,7 +115,7 @@ func main() {
 			}
 
 			impId := getId(imp)
-			fmt.Printf("_%d -> _%d;\n", pkgId, impId)
+			fmt.Printf("%s -> %s;\n", pkgId, impId)
 		}
 	}
 	fmt.Println("}")
@@ -180,11 +179,16 @@ func getImports(pkg *build.Package) []string {
 	return imports
 }
 
-func getId(name string) int {
+func deriveNodeID(packageName string) string {
+	//TODO: improve implementation?
+	id := "\"" + packageName + "\""
+	return id
+}
+
+func getId(name string) string {
 	id, ok := ids[name]
 	if !ok {
-		id = nextId
-		nextId++
+		id = deriveNodeID(name)
 		ids[name] = id
 	}
 	return id


### PR DESCRIPTION
These enhancements enable: 1) human-readable node and edge tooltips for SVGs generated from godepgraph DOT output; 2) easier debugging (and optional suppression via flag) of import errors during processing.

1. The effects of the DOT output changes can be seen by examining the change to the 'expected.txt' file (which was updated via `godepgraph github.com/kisielk/godepgraph > expected.txt`).

2. Prior to the error-related enhancements, godepgraph was unable to successfully process certain packages without explicitly ignoring any dependencies that caused 'processing errors'. And discovering which packages needed to be excluded was difficult because the godepgraph error messages didn't specify which imports/packages had caused processing to fail.