### PR TITLE
Add -vendor flag to ignore vendored packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ godepgraph is a program for generating a dependency graph of Go packages.
 
     go get github.com/kisielk/godepgraph
 
-
 ## Use
 
 For basic usage, just give the package path of interest as the first
@@ -40,6 +39,12 @@ If you want to ignore standard library packages entirely, use the -s flag:
 
     godepgraph -s github.com/kisielk/godepgraph
 
+### Vendored Libraries
+
+If you want to ignore vendored packages entirely, use the -novendor flag:
+
+    godepgraph -novendor github.com/something/else
+
 ### By Name
 
 Import paths can be ignored in a comma-separated list passed to the -i flag:
@@ -66,4 +71,3 @@ Here's some example output for a component of Gary Burd's [gopkgdoc][gopkgdoc] p
 
 [graphviz]: http://graphviz.org
 [gopkgdoc]: https://github.com/garyburd/gopkgdoc
-

--- a/main.go
+++ b/main.go
@@ -22,11 +22,12 @@ var (
 	onlyPrefixes    []string
 
 	ignoreStdlib   = flag.Bool("s", false, "ignore packages in the Go standard library")
+	ignoreVendor   = flag.Bool("novendor", false, "ignore packages in the vendor directory")
 	delveGoroot    = flag.Bool("d", false, "show dependencies of packages in the Go standard library")
 	ignorePrefixes = flag.String("p", "", "a comma-separated list of prefixes to ignore")
 	ignorePackages = flag.String("i", "", "a comma-separated list of packages to ignore")
 	onlyPrefix     = flag.String("o", "", "a comma-separated list of prefixes to include")
-	tagList        = flag.String("tags", "", "a comma-separated list of build tags to consider satisified during the build")
+	tagList        = flag.String("tags", "", "a comma-separated list of build tags to consider satisfied during the build")
 	horizontal     = flag.Bool("horizontal", false, "lay out the dependency graph horizontally instead of vertically")
 	includeTests   = flag.Bool("t", false, "include test packages")
 	maxLevel       = flag.Int("l", 256, "max level of go dependency graph")
@@ -200,6 +201,10 @@ func isIgnored(pkg *build.Package) bool {
 	if len(onlyPrefixes) > 0 && !hasPrefixes(normalizeVendor(pkg.ImportPath), onlyPrefixes) {
 		return true
 	}
+
+	if *ignoreVendor && isVendored(pkg.ImportPath) {
+		return true
+	}
 	return ignored[normalizeVendor(pkg.ImportPath)] || (pkg.Goroot && *ignoreStdlib) || hasPrefixes(normalizeVendor(pkg.ImportPath), ignoredPrefixes)
 }
 
@@ -211,7 +216,11 @@ func debugf(s string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, s, args...)
 }
 
+func isVendored(path string) bool {
+	return strings.Contains(path, "/vendor/")
+}
+
 func normalizeVendor(path string) string {
 	pieces := strings.Split(path, "vendor/")
-	return pieces[len(pieces) - 1]
+	return pieces[len(pieces)-1]
 }


### PR DESCRIPTION
Add flag to ignore the vendored packages. Works best with ignoring
the stdlib too.

Adds isVendored() func checking for vendored libraries. Technically,
it could be incorrect in a few edge cases, but I consider it an
acceptable risk.