### PR TITLE
Display vendored libraries in yellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ godepgraph uses a simple color scheme to denote different types of packages:
 
   * *green*: a package that is part of the Go standard library, installed in `$GOROOT`.
   * *blue*: a regular Go package found in `$GOPATH`.
+  * *yellow*: a vendored Go package found in `$GOPATH`.
   * *orange*: a package found in `$GOPATH` that uses cgo by importing the special package "C".
 
 ## Ignoring Imports
@@ -61,10 +62,8 @@ list of prefixes:
 
     godepgraph -p github.com,launchpad.net bitbucket.org/foo/bar
 
+## Example
 
-
-Example
--------
 Here's some example output for a component of Gary Burd's [gopkgdoc][gopkgdoc] project:
 
 ![Example output](example.png)

--- a/main.go
+++ b/main.go
@@ -98,6 +98,8 @@ func main() {
 			color = "palegreen"
 		} else if len(pkg.CgoFiles) > 0 {
 			color = "darkgoldenrod1"
+		} else if isVendored(pkg.ImportPath) {
+			color = "palegoldenrod"
 		} else {
 			color = "paleturquoise"
 		}


### PR DESCRIPTION
Uses the new `isVendored()` func to display vendored libraries in a
different color than the application being graphed.

Bikeshed avoidance attempt: Yellow is not meant as a warning, but
as a "separate path to the stdlib" since blue + yellow = green.
It's a reach...

Example using `github.com/stretchr/testify` because it's a small project with a vendor directory on my machine.
![testify](https://user-images.githubusercontent.com/195061/45389761-c1433680-b5d1-11e8-8328-d065466f02a3.png)
