### PR TITLE
Improve: use list command to resolve relative import path

### DIFF
--- a/expected.txt
+++ b/expected.txt
@@ -12,11 +12,13 @@ edge [arrowsize="0.5"]
 "github.com/kisielk/godepgraph" -> "go/build";
 "github.com/kisielk/godepgraph" -> "log";
 "github.com/kisielk/godepgraph" -> "os";
+"github.com/kisielk/godepgraph" -> "os/exec";
 "github.com/kisielk/godepgraph" -> "sort";
 "github.com/kisielk/godepgraph" -> "strings";
 "go/build" [label="go/build" color="palegreen" URL="https://godoc.org/go/build" target="_blank"];
 "log" [label="log" color="palegreen" URL="https://godoc.org/log" target="_blank"];
 "os" [label="os" color="palegreen" URL="https://godoc.org/os" target="_blank"];
+"os/exec" [label="os/exec" color="palegreen" URL="https://godoc.org/os/exec" target="_blank"];
 "sort" [label="sort" color="palegreen" URL="https://godoc.org/sort" target="_blank"];
 "strings" [label="strings" color="palegreen" URL="https://godoc.org/strings" target="_blank"];
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"go/build"
 	"log"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 )
@@ -79,8 +80,24 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to get cwd: %s", err)
 	}
-	for _, a := range args {
-		if err := processPackage(cwd, a, 0, "", *stopOnError); err != nil {
+
+	cmdArgs := []string{"list"}
+	if *tagList != "" {
+		cmdArgs = append(cmdArgs, "-tags", *tagList)
+	}
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.Command("go", cmdArgs...)
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	resolved := strings.Fields(string(out))
+
+	for _, pkg := range resolved {
+		if err := processPackage(cwd, pkg, 0, "", *stopOnError); err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
## Why this change?

With a very simple repository for demonstration:

```shell
git clone https://github.com/leventeliu/godepgraph-demo.git
cd godepgraph-demo
```

Initially, when I was trying to get dep-graph inside a go module (given filter `-o <prefix>`) with a [relative import path](https://golang.org/cmd/go/#hdr-Relative_import_paths) syntax, `godepgraph` gave an empty result:

```shell
$ godepgraph -o github.com/leventeliu ./cmd/nop
digraph godep {
splines=ortho
nodesep=0.4
ranksep=0.8
node [shape="box",style="rounded,filled"]
edge [arrowsize="0.5"]
}
```

After some code reading, I found the correct way to do it cloud be:

```shell
$ godepgraph -o .,github.com/leventeliu ./cmd/nop
digraph godep {
splines=ortho
nodesep=0.4
ranksep=0.8
node [shape="box",style="rounded,filled"]
edge [arrowsize="0.5"]
"./cmd/nop" [label="./cmd/nop" color="paleturquoise" URL="https://godoc.org/./cmd/nop" target="_blank"];
"./cmd/nop" -> "github.com/leventeliu/godepgraph-demo/a";
"./cmd/nop" -> "github.com/leventeliu/godepgraph-demo/b";
"github.com/leventeliu/godepgraph-demo/a" [label="github.com/leventeliu/godepgraph-demo/a" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/a" target="_blank"];
"github.com/leventeliu/godepgraph-demo/b" [label="github.com/leventeliu/godepgraph-demo/b" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/b" target="_blank"];
}
```

But it's weird, isn't it? The problem here is that the relative path `./cmd/nop` could (and should) be resolved as a full package path `github.com/leventeliu/godepgraph-demo/cmd/nop`, which will not be ignored by the filter `-o github.com/leventeliu`.

And after I tried the `list` command:

```shell
$ go list ./cmd/nop
github.com/leventeliu/godepgraph-demo/cmd/nop
```

I thought this is the proper way to solve this.

List command is implemented by an internal package, which will be tricky to call directly. Alternatively, I use an `os/exec.Command` to call `go list` and pass the parent environment to the command (any better idea?)

Now it works well:

```shell
$ godepgraph -o github.com/leventeliu ./cmd/nop
digraph godep {
splines=ortho
nodesep=0.4
ranksep=0.8
node [shape="box",style="rounded,filled"]
edge [arrowsize="0.5"]
"github.com/leventeliu/godepgraph-demo/a" [label="github.com/leventeliu/godepgraph-demo/a" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/a" target="_blank"];
"github.com/leventeliu/godepgraph-demo/b" [label="github.com/leventeliu/godepgraph-demo/b" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/b" target="_blank"];
"github.com/leventeliu/godepgraph-demo/cmd/nop" [label="github.com/leventeliu/godepgraph-demo/cmd/nop" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/cmd/nop" target="_blank"];
"github.com/leventeliu/godepgraph-demo/cmd/nop" -> "github.com/leventeliu/godepgraph-demo/a";
"github.com/leventeliu/godepgraph-demo/cmd/nop" -> "github.com/leventeliu/godepgraph-demo/b";
}
```

This improvement applies to the case when you are working with "GOPATH mode", instead of go module, too.

Also, this implies a special pattern `/...` will be supported:

```shell
$ godepgraph -o github.com/leventeliu ./...
digraph godep {
splines=ortho
nodesep=0.4
ranksep=0.8
node [shape="box",style="rounded,filled"]
edge [arrowsize="0.5"]
"github.com/leventeliu/godepgraph-demo/a" [label="github.com/leventeliu/godepgraph-demo/a" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/a" target="_blank"];
"github.com/leventeliu/godepgraph-demo/b" [label="github.com/leventeliu/godepgraph-demo/b" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/b" target="_blank"];
"github.com/leventeliu/godepgraph-demo/cmd/nop" [label="github.com/leventeliu/godepgraph-demo/cmd/nop" color="paleturquoise" URL="https://godoc.org/github.com/leventeliu/godepgraph-demo/cmd/nop" target="_blank"];
"github.com/leventeliu/godepgraph-demo/cmd/nop" -> "github.com/leventeliu/godepgraph-demo/a";
"github.com/leventeliu/godepgraph-demo/cmd/nop" -> "github.com/leventeliu/godepgraph-demo/b";
}
```
