### PR TITLE
[README] go get -> go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ godepgraph is a program for generating a dependency graph of Go packages.
 
 ## Install
 
-    go get github.com/kisielk/godepgraph
+    go install github.com/kisielk/godepgraph@latest
 
 ## Use
 


### PR DESCRIPTION
From https://go.dev/doc/go-get-install-deprecation :
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

We use the version suffix `@latest` so that `go install` will ignore a `go.mod` in the cwd.