### PR TITLE
Implement Mermaid support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ argument:
 
     godepgraph github.com/kisielk/godepgraph
     
-If you intent to graph a go mod project, your package should be passed as a relative path:
+If you intend to graph a go mod project, your package should be passed as a relative path:
 
     godepgraph ./pkg/api
 
-The output is a graph in [Graphviz][graphviz] dot format. If you have the
+The default output is a graph in [Graphviz][graphviz] dot format. If you have the
 graphviz tools installed you can render it by piping the output to dot:
 
     godepgraph github.com/kisielk/godepgraph | dot -Tpng -o godepgraph.png
+
+You can also generate [Mermaid](https://mermaid.js.org/) graphs:
+
+    godepgraph github.com/kisielk/godepgraph -format mermaid > graph.mmd
 
 By default godepgraph will display packages in the standard library in the
 graph, though it will not delve in to their dependencies.

--- a/graphviz_lang.go
+++ b/graphviz_lang.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+)
+
+// graphvizPrinter implements graphPrinter for the DOT / GraphViz diagramming language.
+type graphvizPrinter struct {
+	ids map[string]string
+}
+
+func newGraphvizPrinter() *graphvizPrinter {
+	p := new(graphvizPrinter)
+	p.ids = make(map[string]string)
+	return p
+}
+
+func (p *graphvizPrinter) writeHeader(hLayout bool) {
+	fmt.Println("digraph godep {")
+	if hLayout {
+		fmt.Println(`rankdir="LR"`)
+	}
+	fmt.Println(`splines=ortho
+nodesep=0.4
+ranksep=0.8
+node [shape="box",style="rounded,filled"]
+edge [arrowsize="0.5"]`)
+}
+
+func (p *graphvizPrinter) writeNode(pkgName string, attrs *build.Package) {
+	id := p.getId(pkgName)
+
+	var color string
+	switch {
+	case attrs.Goroot:
+		color = "palegreen"
+	case len(attrs.CgoFiles) > 0:
+		color = "darkgoldenrod1"
+	case isVendored(attrs.ImportPath):
+		color = "palegoldenrod"
+	case hasBuildErrors(attrs):
+		color = "red"
+	default:
+		color = "paleturquoise"
+	}
+
+	fmt.Printf("%s [label=\"%s\" color=\"%s\" URL=\"%s\" target=\"_blank\"];\n", id, pkgName, color, pkgDocsURL(pkgName))
+}
+
+func (p *graphvizPrinter) writeEdge(u string, v string) {
+	uId := p.getId(u)
+	vId := p.getId(v)
+	fmt.Printf("%s -> %s;\n", uId, vId)
+}
+
+func (p *graphvizPrinter) getId(pkgName string) string {
+	id, ok := p.ids[pkgName]
+	if !ok {
+		id = "\"" + pkgName + "\""
+		p.ids[pkgName] = id
+	}
+	return id
+}
+
+func (p *graphvizPrinter) writeEnd() {
+	fmt.Println("}")
+}

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 		}
 
 		if *format == "mermaid" {
-      printMermaidNode(pkg, pkgId, pkgName)
+			printMermaidNode(pkg, pkgId, pkgName)
 		} else {
 			printGraphvizNode(pkg, pkgId, pkgName)
 		}
@@ -310,10 +310,10 @@ func printMermaidHeader() {
 		fmt.Println("flowchart TD")
 	}
 
-	fmt.Println("classDef goroot fill:#1B1")
-	fmt.Println("classDef cgofiles fill:#C52")
-	fmt.Println("classDef vendored fill:#888")
-	fmt.Println("classDef buildErrs fill:#811")
+	fmt.Println("classDef goroot fill:#1D4,color:white")
+	fmt.Println("classDef cgofiles fill:#D52,color:white")
+	fmt.Println("classDef vendored fill:#D90,color:white")
+	fmt.Println("classDef buildErrs fill:#C10,color:white")
 	fmt.Println()
 }
 

--- a/mermaid_lang.go
+++ b/mermaid_lang.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+)
+
+// mermaidPrinter implements graphPrinter for the Mermaid diagramming language.
+type mermaidPrinter struct {
+	ids    map[string]string
+	nextId int
+}
+
+func newMermaidPrinter() *mermaidPrinter {
+	p := new(mermaidPrinter)
+	p.ids = make(map[string]string)
+	return p
+}
+
+func (p *mermaidPrinter) writeHeader(hLayout bool) {
+	if hLayout {
+		fmt.Println("flowchart LR")
+	} else {
+		fmt.Println("flowchart TD")
+	}
+
+	fmt.Println()
+	fmt.Println("classDef goroot fill:#1D4,color:white")
+	fmt.Println("classDef cgofiles fill:#D52,color:white")
+	fmt.Println("classDef vendored fill:#D90,color:white")
+	fmt.Println("classDef buildErrs fill:#C10,color:white")
+}
+
+func (p *mermaidPrinter) writeNode(pkgName string, attrs *build.Package) {
+	id := p.getId(pkgName)
+
+	var classname string
+	switch {
+	case attrs.Goroot:
+		classname = "goroot"
+	case len(attrs.CgoFiles) > 0:
+		classname = "cgofiles"
+	case isVendored(attrs.ImportPath):
+		classname = "vendored"
+	case hasBuildErrors(attrs):
+		classname = "buildErrs"
+	}
+
+	fmt.Println()
+	fmt.Printf("%s[%s]\n", id, pkgName)
+	fmt.Printf("click %s href %q\n", id, pkgDocsURL(pkgName))
+
+	if classname != "" {
+		fmt.Printf("class %s %s\n", id, classname)
+	}
+}
+
+func (p *mermaidPrinter) writeEdge(u string, v string) {
+	uId := p.getId(u)
+	vId := p.getId(v)
+	fmt.Printf("%s --> %s\n", uId, vId)
+}
+
+func (p *mermaidPrinter) getId(pkgName string) string {
+	id, ok := p.ids[pkgName]
+	if !ok {
+		p.nextId = p.nextId + 1
+		id = fmt.Sprintf("%d", p.nextId)
+		p.ids[pkgName] = id
+	}
+	return id
+}
+
+func (p *mermaidPrinter) writeEnd() {}


### PR DESCRIPTION
As per issue #52 this pull request implements support for [Mermaid](https://mermaid.js.org/) graphs.

The default output is still graphviz (dot) but you can specify a different format with `-format`:

```shell
godepgraph -format mermaid github.com/kisielk/godepgraph
```

```mermaid
flowchart TD
classDef goroot fill:#1D4,color:white
classDef cgofiles fill:#D52,color:white
classDef vendored fill:#D90,color:white
classDef buildErrs fill:#C10,color:white

1[flag]
click 1 href "https://godoc.org/flag"
class 1 goroot
2[fmt]
click 2 href "https://godoc.org/fmt"
class 2 goroot
3[github.com/kisielk/godepgraph]
click 3 href "https://godoc.org/github.com/kisielk/godepgraph"
3 --> 1
3 --> 2
3 --> 4
3 --> 5
3 --> 6
3 --> 7
3 --> 8
4[go/build]
click 4 href "https://godoc.org/go/build"
class 4 goroot
5[log]
click 5 href "https://godoc.org/log"
class 5 goroot
6[os]
click 6 href "https://godoc.org/os"
class 6 goroot
7[sort]
click 7 href "https://godoc.org/sort"
class 7 goroot
8[strings]
click 8 href "https://godoc.org/strings"
class 8 goroot
```

### Horizontal layout and special nodes

Here's how it looks with `-horizontal` and the node classes set for cgo, vendored and errored modules:

```mermaid
flowchart LR
classDef goroot fill:#1D4,color:white
classDef cgofiles fill:#D52,color:white
classDef vendored fill:#D90,color:white
classDef buildErrs fill:#C10,color:white

3[some project]
click 3 href "https://godoc.org/github.com/kisielk/godepgraph"
3 --> 4
3 --> 5
3 --> 6
3 --> 7
4[go root]
click 4 href "https://godoc.org/go/build"
class 4 goroot
5[cgo file]
click 5 href "https://godoc.org/log"
class 5 cgofiles
6[vendored]
click 6 href "https://godoc.org/os"
class 6 vendored
7[build errors]
click 7 href "https://godoc.org/sort"
class 7 buildErrs
```

## Considerations

- [x] colours work in light and dark mode rendering on e.g. GitHub
- [x] users can customise the colours using classes
- [x] no changes to dotviz output (piping to `expected.txt` results in no diff)
- [x] new flag is validated with meaningful message
- [x] new flag is documented; feature is mentioned in README 

## Implementation notes

- For mermaid rendering we use the original style of numeric ID generation. Mermaid is picky about what can be in a node's ID and it doesn't like quotes. Numbers should always work.
