### PR TITLE
Add -output flag to write the graph to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ You can also generate [Mermaid](https://mermaid.js.org/) graphs:
 
     godepgraph -format mermaid github.com/kisielk/godepgraph > graph.mmd
 
+To write the graph to a file instead of stdout, use `-output`. If the file
+already exists it is truncated. Omit `-output` (or pass an empty value) to
+print to stdout.
+
+    godepgraph -output deps.dot github.com/kisielk/godepgraph
+    godepgraph -format mermaid -output graph.mmd github.com/kisielk/godepgraph
+
 By default godepgraph will display packages in the standard library in the
 graph, though it will not delve in to their dependencies.
 

--- a/graphviz_lang.go
+++ b/graphviz_lang.go
@@ -3,25 +3,28 @@ package main
 import (
 	"fmt"
 	"go/build"
+	"io"
 )
 
 // graphvizPrinter implements graphPrinter for the DOT / GraphViz diagramming language.
 type graphvizPrinter struct {
+	out io.Writer
 	ids map[string]string
 }
 
-func newGraphvizPrinter() *graphvizPrinter {
+func newGraphvizPrinter(out io.Writer) *graphvizPrinter {
 	p := new(graphvizPrinter)
+	p.out = out
 	p.ids = make(map[string]string)
 	return p
 }
 
 func (p *graphvizPrinter) writeHeader(hLayout bool) {
-	fmt.Println("digraph godep {")
+	fmt.Fprintln(p.out, "digraph godep {")
 	if hLayout {
-		fmt.Println(`rankdir="LR"`)
+		fmt.Fprintln(p.out, `rankdir="LR"`)
 	}
-	fmt.Println(`splines=ortho
+	fmt.Fprintln(p.out, `splines=ortho
 nodesep=0.4
 ranksep=0.8
 node [shape="box",style="rounded,filled"]
@@ -45,13 +48,13 @@ func (p *graphvizPrinter) writeNode(pkgName string, attrs *build.Package) {
 		color = "paleturquoise"
 	}
 
-	fmt.Printf("%s [label=\"%s\" color=\"%s\" URL=\"%s\" target=\"_blank\"];\n", id, pkgName, color, pkgDocsURL(pkgName))
+	fmt.Fprintf(p.out, "%s [label=\"%s\" color=\"%s\" URL=\"%s\" target=\"_blank\"];\n", id, pkgName, color, pkgDocsURL(pkgName))
 }
 
 func (p *graphvizPrinter) writeEdge(u string, v string) {
 	uId := p.getId(u)
 	vId := p.getId(v)
-	fmt.Printf("%s -> %s;\n", uId, vId)
+	fmt.Fprintf(p.out, "%s -> %s;\n", uId, vId)
 }
 
 func (p *graphvizPrinter) getId(pkgName string) string {
@@ -64,5 +67,5 @@ func (p *graphvizPrinter) getId(pkgName string) string {
 }
 
 func (p *graphvizPrinter) writeEnd() {
-	fmt.Println("}")
+	fmt.Fprintln(p.out, "}")
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
+	"io"
 	"log"
 	"os"
 	"sort"
@@ -39,9 +40,11 @@ var (
 	withTests      = flag.Bool("withtests", false, "include test packages")
 	maxLevel       = flag.Int("maxlevel", 256, "max level of go dependency graph")
 	format         = flag.String("format", "dot", "output format of graph (dot, mermaid)")
+	outputPath     = flag.String("output", "", "write graph to this file (empty: stdout); truncate if exists")
 
 	buildTags    []string
-	buildContext = build.Default
+	buildContext           = build.Default
+	writer       io.Writer = io.Writer(os.Stdout)
 )
 
 func init() {
@@ -80,6 +83,15 @@ func main() {
 		buildTags = strings.Split(*tagList, ",")
 	}
 	buildContext.BuildTags = buildTags
+
+	if *outputPath != "" {
+		f, err := os.Create(*outputPath)
+		if err != nil {
+			log.Fatalf("failed to create output file: %s", err)
+		}
+		defer f.Close()
+		writer = f
+	}
 
 	printer, err := getPrinter()
 	if err != nil {
@@ -243,9 +255,9 @@ func normalizeVendor(path string) string {
 func getPrinter() (graphPrinter, error) {
 	switch *format {
 	case "dot":
-		return newGraphvizPrinter(), nil
+		return newGraphvizPrinter(writer), nil
 	case "mermaid":
-		return newMermaidPrinter(), nil
+		return newMermaidPrinter(writer), nil
 	default:
 		return nil, fmt.Errorf("invalid format flag %q, must be: dot, mermaid", *format)
 	}

--- a/mermaid_lang.go
+++ b/mermaid_lang.go
@@ -3,32 +3,35 @@ package main
 import (
 	"fmt"
 	"go/build"
+	"io"
 )
 
 // mermaidPrinter implements graphPrinter for the Mermaid diagramming language.
 type mermaidPrinter struct {
+	out    io.Writer
 	ids    map[string]string
 	nextId int
 }
 
-func newMermaidPrinter() *mermaidPrinter {
+func newMermaidPrinter(out io.Writer) *mermaidPrinter {
 	p := new(mermaidPrinter)
+	p.out = out
 	p.ids = make(map[string]string)
 	return p
 }
 
 func (p *mermaidPrinter) writeHeader(hLayout bool) {
 	if hLayout {
-		fmt.Println("flowchart LR")
+		fmt.Fprintln(p.out, "flowchart LR")
 	} else {
-		fmt.Println("flowchart TD")
+		fmt.Fprintln(p.out, "flowchart TD")
 	}
 
-	fmt.Println()
-	fmt.Println("classDef goroot fill:#1D4,color:white")
-	fmt.Println("classDef cgofiles fill:#D52,color:white")
-	fmt.Println("classDef vendored fill:#D90,color:white")
-	fmt.Println("classDef buildErrs fill:#C10,color:white")
+	fmt.Fprintln(p.out)
+	fmt.Fprintln(p.out, "classDef goroot fill:#1D4,color:white")
+	fmt.Fprintln(p.out, "classDef cgofiles fill:#D52,color:white")
+	fmt.Fprintln(p.out, "classDef vendored fill:#D90,color:white")
+	fmt.Fprintln(p.out, "classDef buildErrs fill:#C10,color:white")
 }
 
 func (p *mermaidPrinter) writeNode(pkgName string, attrs *build.Package) {
@@ -46,19 +49,19 @@ func (p *mermaidPrinter) writeNode(pkgName string, attrs *build.Package) {
 		classname = "buildErrs"
 	}
 
-	fmt.Println()
-	fmt.Printf("%s[%s]\n", id, pkgName)
-	fmt.Printf("click %s href %q\n", id, pkgDocsURL(pkgName))
+	fmt.Fprintln(p.out)
+	fmt.Fprintf(p.out, "%s[%s]\n", id, pkgName)
+	fmt.Fprintf(p.out, "click %s href %q\n", id, pkgDocsURL(pkgName))
 
 	if classname != "" {
-		fmt.Printf("class %s %s\n", id, classname)
+		fmt.Fprintf(p.out, "class %s %s\n", id, classname)
 	}
 }
 
 func (p *mermaidPrinter) writeEdge(u string, v string) {
 	uId := p.getId(u)
 	vId := p.getId(v)
-	fmt.Printf("%s --> %s\n", uId, vId)
+	fmt.Fprintf(p.out, "%s --> %s\n", uId, vId)
 }
 
 func (p *mermaidPrinter) getId(pkgName string) string {


### PR DESCRIPTION
**Summary**
Added an `-output` flag to write dependency graph output (DOT or Mermaid) to a file instead of stdout. Provides a documented `graph → path` option (visible in `-help`) without relying on shell redirects, and surfaces file I/O errors directly from the tool.

**What changed**

* New flag: `-output` - file path for graph output (defaults to stdout if empty).
* Refactor: `graphvizPrinter` and `mermaidPrinter` now accept an `io.Writer` and write via `fmt.Fprint` instead of stdout.

**Usage**

```bash
godepgraph -output deps.dot ./your/package
godepgraph -format mermaid -output deps.mmd ./your/package
```
