### PR TITLE
Entrypoints should never be ignored

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type graphPrinter interface {
 var (
 	pkgs        map[string]*build.Package
 	erroredPkgs map[string]bool
+	entrypoints map[*build.Package]bool
 
 	ignored = map[string]bool{
 		"C": true,
@@ -57,6 +58,7 @@ func init() {
 func main() {
 	pkgs = make(map[string]*build.Package)
 	erroredPkgs = make(map[string]bool)
+	entrypoints = make(map[*build.Package]bool)
 	flag.Parse()
 
 	args := flag.Args()
@@ -151,6 +153,11 @@ func processPackage(root string, pkgName string, level int, importedBy string, s
 		}
 	}
 
+	// Track entry points so they aren't ignored
+	if importedBy == "" {
+		entrypoints[pkg] = true
+	}
+
 	if isIgnored(pkg) {
 		return nil
 	}
@@ -209,6 +216,10 @@ func hasPrefixes(s string, prefixes []string) bool {
 }
 
 func isIgnored(pkg *build.Package) bool {
+	if entrypoints[pkg] {
+		return false
+	}
+
 	if len(onlyPrefixes) > 0 && !hasPrefixes(normalizeVendor(pkg.ImportPath), onlyPrefixes) {
 		return true
 	}


### PR DESCRIPTION
There is a bug (issue #50) where, if the starting point is a file path(s), it doesn't play nicely with ignore rules like `-o / --onlyprefixes`. It returns nothing unless you know you have to pass the magic string `command-line-arguments`:

```
# Assuming the project entrypoint is ./cmd/main.go
godepgraph -s -o github.com/my/project,command-line-arguments cmd/main.go
```

This happens because Go's `build.Import` returns "command-line-arguments" as the ImportPath.

I think the best fix for this is, simply don't ignore packages that are entrypoints. It doesn't make sense to specify a package to traverse and then also ignore it.